### PR TITLE
[WIP] Implement a steady-state solver for 0-D systems

### DIFF
--- a/include/cantera/numerics/Cantera_NonLinSol.h
+++ b/include/cantera/numerics/Cantera_NonLinSol.h
@@ -1,0 +1,88 @@
+/* @file Cantera_NonLinSol.h
+ * A nonlinear algebraic system solver, built upon Cantera's 1D multi-domain damped newton solver.
+ *
+ * Cantera_NonLinSol is a simplified interface to the Cantera solver, designed for solving standard
+ * systems of nonlinear algebraic equations. Systems are solved by Cantera as one-domain, one-point
+ * problems. */
+
+#include "cantera/onedim.h"
+
+class Cantera_NonLinSol : public Cantera::Domain1D
+{
+public:
+/* TO USE THIS SOLVER:
+ *     1. Include this header file in your code.
+ *          #include "path/to/Cantera_NonLinSol.h"
+ *     2. Create a Cantera_NonLinSol child class, where you'll set up your problem.
+ *          class YourClass : public Cantera_NonLinSol
+ *     3. In the child class, provide implementations for problem-specific functions.
+ *          void residFunction(args) { ... }
+ *          doublereal initialValue(size_t i, size_t j) { ... }
+ *          size_t neq() { ... }
+ *     4. Initialize your class and call its inherited solve() function.
+ *          YourClassObject.solve();
+ *     5. (Optional) Reconfigure solver settings. 
+ *          YourClassObject.reconfigure(neq, lowerBound, upperBound, rtol, atol);
+ */
+
+/// IMPLEMENT THESE FUNCTIONS:
+
+    // Specify the residual function for the system
+    //  sol - iteration solution vector (input)
+    //  rsd - residual vector (output)
+    virtual void residFunction(double *sol, double *rsd) = 0;
+
+    // Specify guesses for the initial values.
+    //  Note: called during Sim1D initialization
+    virtual doublereal initialValue(size_t i, size_t j) = 0;
+
+    // Number of equations (state variables) for this reactor
+    virtual size_t neq() = 0;
+
+/// CALLABLE FUNCTIONS:
+
+    void reconfigure(int neq, double lowerBound = -1.0e-3, double upperBound = 1.01,
+                     double rtol = 1.0e-4, double atol = 1.0e-9)
+    {
+        Domain1D::resize(neq, 1);
+        for (int i = 0; i < neq; i++)
+        {
+            Domain1D::setBounds(i, lowerBound, upperBound);
+            Domain1D::setSteadyTolerances(rtol, atol, i);
+            Domain1D::setTransientTolerances(rtol, atol, i);
+            Domain1D::setComponentName(i, std::to_string(i));
+        }
+    }
+
+    /**
+     * Solve the nonlinear algebraic system.
+     * @param loglevel controls amount of diagnostic output.
+     */
+    void solve(int loglevel = 0)
+    {
+        if (Domain1D::nComponents() != neq())
+            reconfigure(neq());
+
+        std::vector<Cantera::Domain1D *> domains{this};
+        Cantera::Sim1D(domains).solve(loglevel);
+    }
+
+private:
+/// INTERNAL FUNCTION:
+
+    // Implementing the residual function for the Cantera solver to use. Handles time integration, calls subclass residFunction for residuals.
+    void eval(size_t jg, double *sol, double *rsd, int *timeintMask, double rdt)
+    {
+        residFunction(sol, rsd); // call subclass residFunction() implementation to update rsd
+
+        if (rdt == 0)
+            return; // rdt is the reciprocal of the time step "dt"; rdt != 0 for time integration...
+
+        // -------------------- TIME INTEGRATION --------------------------
+        for (int i = 0; i < neq(); i++)
+        {
+            rsd[i] -= rdt * (sol[i] - prevSoln(i, 0)); // backward euler method (result will be appropriately extracted from the residual)
+            timeintMask[i] = 1;                        // enable time stepping for this solution component (automatically resets each iteration)
+        }
+    }
+};

--- a/include/cantera/numerics/Cantera_NonLinSol.h
+++ b/include/cantera/numerics/Cantera_NonLinSol.h
@@ -6,10 +6,17 @@
  * problems. */
 
 #include "cantera/onedim.h"
+#include <fstream>
 
 class Cantera_NonLinSol : public Cantera::Domain1D
 {
 public:
+    Cantera_NonLinSol() : outputFile("YOLO.csv") {
+        // outputFile << "time, pressure, enthalpy, temperature, mass, volume, internal energy";
+        // for (int k = 0; k < gas->nSpecies(); k++)
+        //     outputFile << "Y_" << gas->speciesName(k) << ", ";
+        // outputFile << std::endl;
+    }
 /* TO USE THIS SOLVER:
  *     1. Include this header file in your code.
  *          #include "path/to/Cantera_NonLinSol.h"
@@ -54,7 +61,7 @@ public:
         }
         Domain1D::setBounds(0, 0, 100);
         Domain1D::setBounds(1, 0, 5);
-        Domain1D::setBounds(2, -1000000, 1000000);
+        Domain1D::setBounds(2, -10000000, 10000000);
     }
 
     /**
@@ -70,21 +77,51 @@ public:
         Cantera::Sim1D(domains).solve(loglevel);
     }
 
+    std::ofstream outputFile;
+    int counter = 1;
 private:
 /// INTERNAL FUNCTIONS:
+    
 
     // Implementing the residual function for the Cantera solver to use. Handles time integration, calls subclass residFunction for residuals.
     void eval(size_t jg, double *sol, double *rsd, int *timeintMask, double rdt)
     {
+        // std::cout << "\n\n----- sol components -----\n";
+        // for (int i = 0; i < m_nv; i++)
+        //     std::cout << sol[i] << " ";
+
         ctNLS_residFunction(sol, rsd); // call subclass residFunction() implementation to update rsd
+        counter++;
+        // std::cout << "\n\n----- iter" << counter << " sol components -----\n";
+        // for (int i = 0; i < m_nv; i++)
+        //     std::cout << sol[i] << " ";
+        for (int i = 0; i < m_nv; i++)
+            outputFile << sol[i] << ", ";
+        // std::cout << "\n\n----- iter" << counter << " rsd components -----\n";
+        // for (int i = 0; i < m_nv; i++)
+        //     std::cout << rsd[i] << " ";
+        // for (int i = 0; i < m_nv; i++)
+        //     outputFile << rsd[i] << ", ";
+        outputFile << std::endl;
+        
 
-        if (rdt == 0)
+        if (rdt == 0) {
+            //outputFile << "no" << std::endl;
+            //std::cout << "no" << std::endl;
             return; // rdt is the reciprocal of the time step "dt"; rdt != 0 for time integration...
-
+        }
+        
+        //outputFile << "yes" << std::endl;
+        //std::cout << "yes" << std::endl;
         // -------------------- TIME INTEGRATION --------------------------
         for (int i = 0; i < ctNLS_nEqs(); i++)
         {
+            std::cout << "time step " << rdt * (sol[i] - prevSoln(i, 0)) << "\n";
+            if(i == 0)
+                std::cout << "\ntimestep:\nsol[0]: " << sol[0] << " prevsoln[0]: " << prevSoln(0,0) << " rsd " << rsd[i] << " rsd -= " << rdt * (sol[i] - prevSoln(i, 0));
             rsd[i] -= rdt * (sol[i] - prevSoln(i, 0)); // backward euler method (result will be appropriately extracted from the residual)
+            if(i==0)
+                std::cout << " rsd = " << rsd[i] << "\n";
             timeintMask[i] = 1;                        // enable time stepping for this solution component (automatically resets each iteration)
         }
     }

--- a/include/cantera/numerics/Cantera_NonLinSol.h
+++ b/include/cantera/numerics/Cantera_NonLinSol.h
@@ -52,6 +52,9 @@ public:
             Domain1D::setTransientTolerances(rtol, atol, i);
             Domain1D::setComponentName(i, std::to_string(i));
         }
+        Domain1D::setBounds(0, 0, 100);
+        Domain1D::setBounds(1, 0, 5);
+        Domain1D::setBounds(2, -1000000, 1000000);
     }
 
     /**

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -58,6 +58,7 @@ public:
         if (time != -999.0) {
             updateMassFlowRate(time);
         }
+        // std::cout << "\n -at t = " << time << " ID " << this << " returns " << m_mdot;
         return m_mdot;
     }
 

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -166,6 +166,15 @@ public:
     //! @param limit value for step size limit
     void setAdvanceLimit(const std::string& nm, const double limit);
 
+    // Specify the residual function for the system
+    //  sol - iteration solution vector (input)
+    //  rsd - residual vector (output)
+    virtual void residFunction(double *sol, double *rsd);
+
+    // Specify guesses for the initial values.
+    // Note: called during Sim1D initialization
+    virtual doublereal initialValue(size_t i);
+
 protected:
     //! Set reaction rate multipliers based on the sensitivity variables in
     //! *params*.

--- a/samples/cxx/psr/BoundaryValueProblem.h
+++ b/samples/cxx/psr/BoundaryValueProblem.h
@@ -1,0 +1,292 @@
+/// @file BoundaryValueProblem.h
+/// Simplified interface to the capabilities provided by Cantera to
+/// solve boundary value problems.
+
+#ifndef BVP_H
+#define BVP_H
+
+#include "cantera/onedim.h"
+#include <fstream>
+
+/// Namespace for the boundary value problem package.
+namespace BVP
+{
+
+// default grid refinement parameters
+const double max_grid_ratio = 4.0; ///< max ratio of neighboring grid intervals
+const double max_delta = 0.01; ///< max difference in function values
+const double max_delta_slope = 0.02; ///< max difference in slopes
+const double prune = 0.000; ///< don't remove grid points
+
+/**
+ * Used to specify component-specific options for method
+ * setComponent of method BoundaryValueProblem. An instance of
+ * class Component should be created for each solution component,
+ * and its values set appropriately.
+ */
+class Component
+{
+public:
+    double lower; ///< lower bound
+    double upper; ///< upper bound
+    double rtol; ///< relative error tolerance
+    double atol; ///< absolute error tolerance
+    bool refine; ///< make this component active for grid refinement
+    std::string name; ///< component name
+
+    /**
+     * Constructor. Sets default values.
+     */
+    Component() : lower(0.0), upper(1.0), rtol(1.0e-9), atol(1.0e-12),
+        refine(true) {}
+};
+
+/**
+ * Base class for boundary value problems. This class is designed
+ * to provide a simplified interface to the capabilities Cantera
+ * provides to solve boundary value problems. Classes for specific
+ * boundary value problems should be derived from this one.
+ *
+ * Class BoundaryValueProblem derives from Cantera's Domain1D
+ * class.
+ */
+class BoundaryValueProblem : public Cantera::Domain1D
+{
+
+public:
+
+    /**
+     * Constructor. This constructor begins with a uniform grid of
+     * np points starting at zmin, and ending at zmax.
+     *
+     * @param nv Number of solution components
+     * @param np Number of grid points in initial grid
+     * @param zmin Location of left-hand side of domain
+     * @param zmax Location of right-hand side of domain
+     */
+    BoundaryValueProblem(int nv, int np,
+                         doublereal zmin, doublereal zmax) :
+        m_left(0), m_right(0), m_sim(0)
+    {
+        // Create the initial uniform grid
+        Cantera::vector_fp z(np);
+        int iz;
+        for (iz = 0; iz < np; iz++) {
+            z[iz] = zmin + iz*(zmax - zmin)/(np-1);
+        }
+        setupGrid(np, z.data());
+        resize(nv, np);
+    }
+
+    /**
+     * Constructor. This alternate constructor starts with a
+     * specified grid, unlike the above that uses a uniform grid
+     * to start. The array z must contain the z coordinates of np
+     * grid points.
+     */
+    BoundaryValueProblem(int nv, int np,
+                         doublereal* z) :
+        m_left(0), m_right(0), m_sim(0)
+    {
+        setupGrid(np, z);
+        resize(nv, np);
+    }
+
+    /**
+     * Destructor. Deletes the dummy terminator domains, and the
+     * solver.
+     */
+    virtual ~BoundaryValueProblem() {
+        delete m_left;
+        delete m_right;
+        delete m_sim;
+    }
+
+    /**
+     *  Set parameters and options for solution component \a n.
+     *  This method should be invoked for each solution component
+     *  before calling 'solve'. The parameter values should first
+     *  be set by creating an instance of class Component, and
+     *  setting its member data appropriately.
+     *
+     *  @param n Component number.
+     *  @param c Component parameter values
+     */
+    void setComponent(size_t n, Component& c) {
+        if (m_sim == 0) {
+            start();
+        }
+        if (n >= m_nv) {
+            throw Cantera::CanteraError("BoundaryValueProblem::setComponent",
+                                        "Illegal solution component number");
+        }
+        // set the upper and lower bounds for this component
+        setBounds(n, c.lower, c.upper);
+        // set the error tolerances
+        setSteadyTolerances(c.rtol, c.atol, n);
+        setTransientTolerances(c.rtol, c.atol, n);
+        // specify whether this component should be considered in
+        // refining the grid
+        m_refiner->setActive(n, c.refine);
+        // set a default name if one has not been entered
+        if (c.name == "") {
+            c.name = fmt::format("Component {}", n);
+        }
+        setComponentName(n, c.name);
+    }
+
+    /**
+     * Solve the boundary value problem.
+     * @param loglevel controls amount of diagnostic output.
+     */
+    void solve(int loglevel=0) {
+        if (m_sim == 0) {
+            start();
+        }
+        bool refine = true;
+        m_sim->solve(loglevel, refine);
+    }
+
+    /**
+     * Write the solution to a CSV file.
+     * @param filename CSV file name.
+     * @param ztitle Title for 'z' column.
+     * @param dotitles If true, begin with a row of column titles.
+     */
+    void writeCSV(std::string filename = "output.csv",
+                  bool dotitles = true, std::string ztitle = "z") const {
+        std::ofstream f(filename);
+        int np = nPoints();
+        int nc = nComponents();
+        int n, m;
+        if (dotitles) {
+            f << ztitle << ", ";
+            for (m = 0; m < nc; m++) {
+                f << componentName(m) << ", ";
+            }
+            f << std::endl;
+        }
+        for (n = 0; n < np; n++) {
+            f << z(n) << ", ";
+            for (m = 0; m < nc; m++) {
+                f << m_sim->value(1, m, n) << ", ";
+            }
+            f << std::endl;
+        }
+    }
+
+    /**
+     * Initial value of solution component \a n at initial grid
+     * point \a j. The default is zero for all components at all
+     * grid points. Overload in derived classes to specify other
+     * choices for initial values.
+     */
+    virtual doublereal initialValue(size_t n, size_t j) {
+        return 0.0;
+    }
+
+protected:
+    Cantera::Domain1D* m_left; ///< dummy terminator
+    Cantera::Domain1D* m_right; ///< dummy terminator
+    Cantera::Sim1D* m_sim; ///< controller for solution
+
+    /**
+     * Set up the problem. Creates the solver instance, and sets
+     * default grid refinement parameters. This method is called
+     * internally, and does not need to be invoked explicitly in
+     * derived classes.
+     */
+    void start() {
+        // Add dummy terminator domains on either side of this one.
+        m_left = new Cantera::Empty1D;
+        m_right = new Cantera::Empty1D;
+        std::vector<Cantera::Domain1D*> domains { m_left, this, m_right };
+
+        // create the Sim1D instance that will control the
+        // solution process
+        m_sim = new Cantera::Sim1D(domains);
+
+        // set default grid refinement parameters
+        m_sim->setRefineCriteria(1, max_grid_ratio, max_delta,
+                                 max_delta_slope, prune);
+    }
+
+    /**
+     * @name Trial Solution Derivatives
+     * These methods return
+     * derivatives of individual components at specified grid
+     * points, using a given trial solution.  They are designed
+     * for use in writing overloaded versions of method 'residual'
+     * in derived classes.
+     */
+
+    //@{
+
+    /**
+     * This method is provided for use in method residual when
+     * central-differenced second derivatives are needed.
+     * @param x The current trial solution vector.
+     * @param n Component index.
+     * @param j Grid point number.
+     */
+    doublereal cdif2(const doublereal* x, int n, int j) const {
+        doublereal c1 = value(x,n,j) - value(x,n,j-1);
+        doublereal c2 = value(x,n,j+1) - value(x,n,j);
+        return 2.0*(c2/(z(j+1) - z(j)) - c1/(z(j) - z(j-1)))/
+               (z(j+1) - z(j-1));
+    }
+
+    /**
+     * The first derivative of solution component n at point j.
+     * If type is -1, the first derivative is computed using the
+     * value to the left of point j, if it is +1 then the
+     * value to the right is used, and if it is zero (default) a
+     * central-differenced first derivative is computed.
+    */
+    doublereal firstDeriv(const doublereal* x, int n, int j,
+                          int type = 0) const {
+        switch (type) {
+        case -1:
+            return leftFirstDeriv(x, n, j);
+        case 1:
+            return rightFirstDeriv(x, n, j);
+        default:
+            return centralFirstDeriv(x, n, j);
+        }
+    }
+
+    /**
+     * First derivative of component \a n at point \a j. The derivative
+     * is formed to the right of point j, using values at point j
+     * and point j + 1.
+     */
+    doublereal rightFirstDeriv(const doublereal* x, int n, int j) const {
+        return (value(x,n,j+1) - value(x,n,j))/(z(j+1) - z(j));
+    }
+
+    /**
+     * First derivative of component \a n at point \a j. The derivative
+     * is formed to the left of point j, using values at point j
+     * and point j - 1.
+     */
+
+    doublereal leftFirstDeriv(const doublereal* x, int n, int j) const {
+        return (value(x,n,j) - value(x,n,j-1))/(z(j) - z(j-1));
+    }
+
+    /**
+     * This method is provided for use in method residual when
+     * central-differenced first derivatives are needed.
+     * @param x The current trial solution vector.
+     * @param n Component index.
+     * @param j Grid point number.
+     */
+    doublereal centralFirstDeriv(const doublereal* x, int n, int j) const {
+        doublereal c1 = value(x,n,j+1) - value(x,n,j-1);
+        return c1/(z(j+1) - z(j-1));
+    }
+
+    //@}
+};
+}
+#endif

--- a/samples/cxx/psr/Cantera1D_NonLinSol.h
+++ b/samples/cxx/psr/Cantera1D_NonLinSol.h
@@ -1,0 +1,83 @@
+/// @file Cantera1D_NonLinSol.h
+/// A nonlinear algebraic system solver, built on top of Cantera's 1D solver.
+
+#include "cantera/onedim.h"
+#include "NonLinSol_user.h"
+
+class Cantera1D_NonLinSol : public Cantera::Domain1D
+{
+public:
+    /// Constructor
+    Cantera1D_NonLinSol(NonLinSol_user *user)
+        : Cantera::Domain1D(user->neq()), //initialize base class
+          m_user(user),                   //pointer to user class, to call user defined functions
+          m_neq(user->neq())              //number of equations
+    {
+        // ------------------ INITIALIZE DOMAINS + SIMULATOR ------------------
+        m_left = new Cantera::Empty1D;                                   // dummy terminator
+        m_right = new Cantera::Empty1D;                                  // dummy terminator
+        std::vector<Cantera::Domain1D *> domains{m_left, this, m_right}; // vector of pointers to domains to be linked (reqd to init sim1D)
+        m_sim = new Cantera::Sim1D(domains);                             // Sim1D instance that will control the solution process
+
+        // ------------------ INITIALIZE SOLUTION COMPONENTS ------------------
+        // bounds and error tolerances for all solution components
+        double lower = -1.0e-3;
+        double upper = 1.01;
+        double rtol = 1.0e-4;
+        double atol = 1.0e-9;
+
+        for (int i = 0; i < m_neq; i++)
+        {
+            setBounds(i, lower, upper); //methods inherited from Domain1D
+            setSteadyTolerances(rtol, atol, i);
+            setTransientTolerances(rtol, atol, i);
+            setComponentName(i, std::to_string(i));
+        }
+    }
+
+    /// Destructor. Deletes the dummy terminator domains, and the solver.
+    ~Cantera1D_NonLinSol()
+    {
+        delete m_left;
+        delete m_right;
+        delete m_sim;
+    }
+
+    doublereal initialValue(size_t i, size_t j)
+    {
+        return m_user->initialGuess(i, j); //use pointer to user class to call user-supplied initial function
+    }
+
+    /**
+     * Solve the nonlinear algebraic system.
+     * @param loglevel controls amount of diagnostic output.
+     */
+    void solve(int loglevel = 0)
+    {
+        m_sim->solve(loglevel); // call sim1D's solver
+    }
+
+    // Specify the residual function. The solver will attempt to find a solution
+    // sol so that rsd is zero.
+    void eval(size_t jg, double *sol, double *rsd, int *timeintMask, double rdt)
+    {
+        m_user->residFunction(sol, rsd); // call subclass residFunction() implementation to update rsd
+
+        if (rdt == 0)
+            return; // rdt is the reciprocal of the time step "dt"; rdt != 0 for time integration...
+
+        // -------------------- TIME INTEGRATION --------------------------
+        for (int i = 0; i < m_neq; i++)
+        {
+            rsd[i] -= rdt * (sol[i] - prevSoln(i, 0)); // backward euler method (result will be appropriately extracted from the residual)
+            timeintMask[i] = 1;                        // enable time stepping for this solution component (automatically resets each iteration)
+        }
+    }
+
+private:
+    NonLinSol_user *m_user;
+    Cantera::Domain1D *m_left;
+    Cantera::Domain1D *m_right;
+    Cantera::Sim1D *m_sim;
+    int m_neq;
+};

--- a/samples/cxx/psr/NonLinSol_user.h
+++ b/samples/cxx/psr/NonLinSol_user.h
@@ -1,0 +1,30 @@
+/// @file NonLinSol_user.h
+/// An interface to enable the use of nonlinear algebraic solver applications.
+/// -> Derive classes from `NonLinSol_user` to provide residual and initial guess functions to a nonlinsolver
+
+#ifndef CT_NLS_H
+#define CT_NLS_H
+
+#include "cantera/base/ct_defs.h"
+#include "cantera/base/ctexceptions.h"
+#include "cantera/base/global.h"
+
+class NonLinSol_user
+{
+public:
+    NonLinSol_user(){};
+    ~NonLinSol_user(){};
+
+    // Specify the residual function for the system
+    //  sol - iteration solution vector (input)
+    //  rsd - residual vector (output)
+    virtual void residFunction(double *sol, double *rsd) = 0;
+
+    // Specify guesses for the initial values.
+    // Note: called during Sim1D initialization
+    virtual doublereal initialGuess(size_t i, size_t j) = 0;
+
+    // Number of equations (state variables) for this reactor
+    virtual size_t neq() = 0;
+};
+#endif

--- a/samples/cxx/psr/PSRv0-3.cpp
+++ b/samples/cxx/psr/PSRv0-3.cpp
@@ -30,13 +30,13 @@ public:
 
     // Specify guesses for the initial values.
     // Note: called during Sim1D initialization
-    doublereal initialValue(size_t i, size_t j)
+    doublereal ctNLS_initialValue(size_t i, size_t j)
     {
         return reactorThermo->massFraction(i); // mass fractions of the provided intial reactorSol (aka the initial guess)
     }
 
     // Number of equations (state variables) for this reactor
-    size_t neq()
+    size_t ctNLS_nEqs()
     {
         return nSpecies;
     }
@@ -50,7 +50,7 @@ public:
     // Specify the residual function for the system
     //  sol - iteration solution vector (input)
     //  rsd - residual vector (output)
-    void residFunction(double *sol, double *rsd)
+    void ctNLS_residFunction(double *sol, double *rsd)
     {
         // ----------------------- UPDATE REACTOR STATE -----------------------
         reactorThermo->setMassFractions_NoNorm(sol);

--- a/samples/cxx/psr/PSRv0-3.cpp
+++ b/samples/cxx/psr/PSRv0-3.cpp
@@ -30,7 +30,7 @@ public:
 
     // Specify guesses for the initial values.
     // Note: called during Sim1D initialization
-    doublereal ctNLS_initialValue(size_t i, size_t j)
+    doublereal ctNLS_initialValue(size_t i)
     {
         return reactorThermo->massFraction(i); // mass fractions of the provided intial reactorSol (aka the initial guess)
     }

--- a/samples/cxx/psr/PSRv0-3.cpp
+++ b/samples/cxx/psr/PSRv0-3.cpp
@@ -1,0 +1,111 @@
+/// @file PSRv0-3.cpp
+/// Perfectly Stirred Reactor Solver (v0.3)
+/// Changes since v0.2.1:
+///     - Created a separate module for nonlinear system solution (Cantera1D_NonLinSol)
+///     - Removed nonlinear solver capability from PSR, which now uses Cantera1D_NonLinSol for that
+
+#include "Cantera1D_NonLinSol.h" //a nonlinear algebraic system solver
+#include "NonLinSol_user.h"      //interface for using a nonlinear solver
+
+const char *MECHANISM = "gri30.yaml";
+const double PRESSURE = Cantera::OneAtm;
+
+class PSR : public NonLinSol_user //inherit nonlinear solver use capability
+{
+public:
+    // Constructor
+    PSR(std::shared_ptr<Cantera::Solution> inletSol, std::shared_ptr<Cantera::Solution> reactorSol, double mdot, double volume)
+    // ------------------------ INITIALIZE GLOBAL VARS ------------------------
+    : inletThermo(inletSol->thermo()),
+      reactorThermo(reactorSol->thermo()),
+      reactorKinetics(reactorSol->kinetics()),
+      nSpecies(inletSol->thermo()->nSpecies()),
+      Y_in(inletSol->thermo()->massFractions()),               // mass fractions at the inlet
+      molecularWeight(inletSol->thermo()->molecularWeights()), // molecular weight of each species (these never change)
+      volume(volume),
+      mdot(mdot)
+    {
+    }
+
+    // Specify guesses for the initial values.
+    // Note: called during Sim1D initialization
+    doublereal initialGuess(size_t i, size_t j)
+    {
+        return reactorThermo->massFraction(i); // mass fractions of the provided intial reactorSol (aka the initial guess)
+    }
+
+    // Number of equations (state variables) for this reactor
+    size_t neq()
+    {
+        return nSpecies;
+    }
+
+    // Advance the PSR to steady state
+    void solveSteady()
+    {
+        Cantera1D_NonLinSol(this).solve(); //probably have to free this object... but classes derived from Domain1D can't be assigned. planning on changing this line, but works for now.
+    }
+
+    // Specify the residual function for the system
+    //  sol - iteration solution vector (input)
+    //  rsd - residual vector (output)
+    void residFunction(double *sol, double *rsd)
+    {
+        // ----------------------- UPDATE REACTOR STATE -----------------------
+        reactorThermo->setMassFractions_NoNorm(sol);
+        // reactorThermo->setMassFractions(sol); -> alternative method, will compare performance between the two
+
+        reactorThermo->setState_HP(inletThermo->enthalpy_mass(), PRESSURE); // keep total enthalpy constant, allow Cantera to control reactor temperature
+
+        // ----------------------- GET REQ'D PROPERTIES -----------------------
+        doublereal wdot[nSpecies];
+        reactorKinetics->getNetProductionRates(wdot);
+
+        // ----------------------- SPECIES CONSERVATION -----------------------
+        for (int k = 0; k < nSpecies; k++)
+        {
+            rsd[k] = wdot[k] * molecularWeight[k] * volume + mdot * (Y_in[k] - sol[k]); //PSR residual equation
+        }
+    }
+
+private:
+    std::shared_ptr<Cantera::ThermoPhase> inletThermo;
+    std::shared_ptr<Cantera::ThermoPhase> reactorThermo;
+    std::shared_ptr<Cantera::Kinetics> reactorKinetics;
+    int nSpecies;
+    const double *Y_in;
+    Cantera::vector_fp molecularWeight;
+    double volume;
+    double mdot;
+};
+
+int main()
+{
+    try
+    {
+        std::shared_ptr<Cantera::Solution> mixInlet(Cantera::newSolution(MECHANISM));
+        std::shared_ptr<Cantera::Solution> mixOutlet(Cantera::newSolution(MECHANISM));
+        mixInlet->thermo()->setState_TPX(300, PRESSURE, "O2:1 CH4:0.5 N2:3.76");
+        mixOutlet->thermo()->setState_TPX(300, PRESSURE, "O2:1 CH4:0.5 N2:3.76");
+        mixOutlet->thermo()->equilibrate("HP");
+
+        double mdot;
+        double volume;
+        std::cout << "Enter mdot: ";
+        std::cin >> mdot;
+        std::cout << "Enter volume: ";
+        std::cin >> volume;
+
+        PSR reactor(mixInlet, mixOutlet, mdot, volume);
+        reactor.solveSteady();
+
+        std::cout << mixOutlet->thermo()->report() << "\n";
+
+        return 0;
+    }
+    catch (Cantera::CanteraError &err)
+    {
+        std::cerr << err.what() << std::endl;
+        return -1;
+    }
+}

--- a/samples/cxx/psr/PSRv0-3.cpp
+++ b/samples/cxx/psr/PSRv0-3.cpp
@@ -2,15 +2,14 @@
 /// Perfectly Stirred Reactor Solver (v0.3)
 /// Changes since v0.2.1:
 ///     - Created a separate module for nonlinear system solution (Cantera1D_NonLinSol)
-///     - Removed nonlinear solver capability from PSR, which now uses Cantera1D_NonLinSol for that
+///     - Removed nonlinear solver capability from PSR
 
-#include "Cantera1D_NonLinSol.h" //a nonlinear algebraic system solver
-#include "NonLinSol_user.h"      //interface for using a nonlinear solver
+#include "cantera/numerics/Cantera_NonLinSol.h" //a nonlinear algebraic system solver
 
 const char *MECHANISM = "gri30.yaml";
 const double PRESSURE = Cantera::OneAtm;
 
-class PSR : public NonLinSol_user //inherit nonlinear solver use capability
+class PSR : public Cantera_NonLinSol //inherit nonlinear solver functionality
 {
 public:
     // Constructor
@@ -27,9 +26,11 @@ public:
     {
     }
 
+    /// Providing implementations for the solver's virtual functions:
+
     // Specify guesses for the initial values.
     // Note: called during Sim1D initialization
-    doublereal initialGuess(size_t i, size_t j)
+    doublereal initialValue(size_t i, size_t j)
     {
         return reactorThermo->massFraction(i); // mass fractions of the provided intial reactorSol (aka the initial guess)
     }
@@ -43,7 +44,7 @@ public:
     // Advance the PSR to steady state
     void solveSteady()
     {
-        Cantera1D_NonLinSol(this).solve(); //probably have to free this object... but classes derived from Domain1D can't be assigned. planning on changing this line, but works for now.
+        Cantera_NonLinSol::solve();
     }
 
     // Specify the residual function for the system
@@ -53,8 +54,6 @@ public:
     {
         // ----------------------- UPDATE REACTOR STATE -----------------------
         reactorThermo->setMassFractions_NoNorm(sol);
-        // reactorThermo->setMassFractions(sol); -> alternative method, will compare performance between the two
-
         reactorThermo->setState_HP(inletThermo->enthalpy_mass(), PRESSURE); // keep total enthalpy constant, allow Cantera to control reactor temperature
 
         // ----------------------- GET REQ'D PROPERTIES -----------------------

--- a/samples/cxx/psr/PSRv0-4.cpp
+++ b/samples/cxx/psr/PSRv0-4.cpp
@@ -1,0 +1,52 @@
+/// @file PSRv0-4.cpp
+/// Perfectly Stirred Reactor Solver (v0.4)
+
+#include "cantera/zerodim.h"
+
+using namespace Cantera;
+
+const char *MECHANISM = "gri30.yaml";
+const double PRESSURE = Cantera::OneAtm;
+
+int main()
+{
+    try
+    {
+        auto sol = newSolution("gri30.yaml", "gri30", "None");
+        auto gas = sol->thermo();
+
+        Reservoir inlet;
+        gas->setState_TPX(300, PRESSURE, "O2:1 CH4:0.5 N2:3.76");
+        inlet.insert(sol);
+
+        Reactor combustor;
+        gas->setState_TPX(300, PRESSURE, "O2:1 CH4:0.5 N2:3.76");
+        gas->equilibrate("HP");
+        combustor.insert(sol);
+        combustor.setInitialVolume(1.0);
+
+        Reservoir exhaust;
+        exhaust.insert(sol);
+
+        MassFlowController m1;
+        m1.install(inlet, combustor);
+        m1.setMassFlowRate(1000);
+
+        Valve v;
+        v.install(combustor, exhaust);
+        v.setValveCoeff(1.0);
+
+        ReactorNet sim;
+        sim.addReactor(combustor);
+
+        sim.initialize();
+        sim.solveSteady();
+        std::cout << combustor.temperature();
+        return 0;
+    }
+    catch (Cantera::CanteraError &err)
+    {
+        std::cerr << err.what() << std::endl;
+        return -1;
+    }
+}

--- a/samples/cxx/psr/PSRv0-4.cpp
+++ b/samples/cxx/psr/PSRv0-4.cpp
@@ -30,7 +30,8 @@ int main()
 
         MassFlowController m1;
         m1.install(inlet, combustor);
-        m1.setMassFlowRate(1000);
+        m1.setMassFlowRate(100);
+        m1.updateMassFlowRate(0);
 
         Valve v;
         v.install(combustor, exhaust);
@@ -39,9 +40,8 @@ int main()
         ReactorNet sim;
         sim.addReactor(combustor);
 
-        sim.initialize();
         sim.solveSteady();
-        std::cout << combustor.temperature();
+        std::cout << combustor.contents().report();
         return 0;
     }
     catch (Cantera::CanteraError &err)

--- a/samples/cxx/psr/PSRv1.cpp
+++ b/samples/cxx/psr/PSRv1.cpp
@@ -1,4 +1,4 @@
-/// @file psr.cpp
+/// @file PSRv1.cpp
 /// Perfectly Stirred Reactor (v0.1)
 
 #include "BoundaryValueProblem.h"

--- a/samples/cxx/psr/PSRv2-1.cpp
+++ b/samples/cxx/psr/PSRv2-1.cpp
@@ -1,0 +1,155 @@
+/// @file PSRv2-1.cpp
+/// Perfectly Stirred Reactor Solver (v0.2.1)
+/// Changes since v0.2:
+///     - Remove dependence on BVP interface
+///     - Remove unused energy and fixed-temp solvers for better readability
+
+#include "cantera/onedim.h" // general header for all 1D reacting flow problems (1D solver is used for this problem)
+
+const char *MECHANISM = "gri30.yaml";
+const double PRESSURE = Cantera::OneAtm;
+
+class PSR : public Cantera::Domain1D
+{
+public:
+    // constructor
+    PSR(std::shared_ptr<Cantera::Solution> inletSol, std::shared_ptr<Cantera::Solution> reactorSol, double mdot, double volume)
+    // ------------------------ INITIALIZE GLOBAL VARS ------------------------
+    : Cantera::Domain1D(inletSol->thermo()->nSpecies()),
+      inletThermo(inletSol->thermo()),
+      reactorThermo(reactorSol->thermo()),
+      reactorKinetics(reactorSol->kinetics()),
+      nSpecies(inletSol->thermo()->nSpecies()),
+      Y_in(inletSol->thermo()->massFractions()),               // mass fractions at the inlet
+      molecularWeight(inletSol->thermo()->molecularWeights()), // molecular weight of each species (these never change)
+      volume(volume),
+      mdot(mdot)
+    {
+        // ------------------ INITIALIZE DOMAINS + SIMULATOR ------------------
+        m_left = new Cantera::Empty1D;  // dummy terminator
+        m_right = new Cantera::Empty1D; // dummy terminator
+
+        std::vector<Cantera::Domain1D *> domains{m_left, this, m_right};
+        m_sim = new Cantera::Sim1D(domains); // Sim1D instance that will control the solution process
+
+        // ------------------ INITIALIZE SOLUTION COMPONENTS ------------------
+        // solution vector contains nSpecies reactor mass fractions, ordered by species index.
+        // i.e.:
+        //     sol = | Y_0 | Y_1 | Y_2 | ... | Y_(nSpecies-1) |
+
+        // bounds and error tolerances for solution mass fractions
+        double lower = -1.0e-3;
+        double upper = 1.01;
+        double rtol = 1.0e-4;
+        double atol = 1.0e-9;
+
+        for (int k = 0; k < nSpecies; k++)
+        {
+            setBounds(k, lower, upper);
+            setSteadyTolerances(rtol, atol, k);
+            setTransientTolerances(rtol, atol, k);
+            setComponentName(k, inletThermo->speciesName(k));
+        }
+    }
+
+    /// Destructor. Deletes the dummy terminator domains, and the solver.
+    virtual ~PSR()
+    {
+        delete m_left;
+        delete m_right;
+        delete m_sim;
+    }
+
+    // Specify guesses for the initial values.
+    virtual doublereal initialValue(size_t i, size_t j)
+    {
+        return reactorThermo->massFraction(i); // mass fractions of the provided intial reactorSol (aka the initial guess)
+    }
+
+    /**
+     * Solve the PSR problem.
+     * @param loglevel controls amount of diagnostic output.
+     */
+    void solve(int loglevel = 0)
+    {
+        m_sim->solve(loglevel); // call sim1D's solver
+    }
+
+    // Specify the residual function. The solver will attempt to find a solution
+    // sol so that rsd is zero.
+    void eval(size_t jg, double *sol, double *rsd, int *diag, double rdt)
+    {
+        size_t j = 0; // current grid point (only one point in a 0D problem...)
+
+        // ----------------------- UPDATE REACTOR STATE -----------------------
+        reactorThermo->setMassFractions_NoNorm(sol);
+        // reactorThermo->setMassFractions(sol); -> alternative method, will compare performance between the two
+
+        reactorThermo->setState_HP(inletThermo->enthalpy_mass(), PRESSURE); // keep total enthalpy constant, allow Cantera to control reactor temperature
+
+        // ----------------------- GET REQ'D PROPERTIES -----------------------
+        double reactorDensity = reactorThermo->density();
+        double resTime = volume * reactorDensity / mdot;
+
+        doublereal wdot[nSpecies];
+        reactorKinetics->getNetProductionRates(wdot);
+
+        // ----------------------- SPECIES CONSERVATION -----------------------
+        for (int k = 0; k < nSpecies; k++)
+        {
+            rsd[k] = wdot[k] * (molecularWeight[k] / reactorDensity) - (sol[k] - Y_in[k]) / resTime;
+            //rsd[k] = wdot[k] * molecularWeight[k] * volume + mdot * (Y_in[k] - sol[k]) -> alternative method (should be equivalent)
+
+            // -------------------- TIME INTEGRATION --------------------------
+            if (rdt != 0) // rdt is the reciprocal of the time step "dt".
+            {
+                rsd[k] -= rdt * (sol[k] - prevSoln(k, j)); // backward euler method (will be extracted from the residual)
+                diag[k] = 1;                               // enable time stepping for this solution component (automatically resets each iteration)
+            }
+        }
+    }
+
+private:
+    Cantera::Domain1D *m_left;
+    Cantera::Domain1D *m_right;
+    Cantera::Sim1D *m_sim;
+    std::shared_ptr<Cantera::ThermoPhase> inletThermo;
+    std::shared_ptr<Cantera::ThermoPhase> reactorThermo;
+    std::shared_ptr<Cantera::Kinetics> reactorKinetics;
+    const int nSpecies;
+    const double *Y_in;
+    Cantera::vector_fp molecularWeight;
+    double volume;
+    double mdot;
+};
+
+int main()
+{
+    try
+    {
+        std::shared_ptr<Cantera::Solution> mixInlet(Cantera::newSolution(MECHANISM));
+        std::shared_ptr<Cantera::Solution> mixOutlet(Cantera::newSolution(MECHANISM));
+        mixInlet->thermo()->setState_TPX(300, PRESSURE, "O2:1 CH4:0.5 N2:3.76");
+        mixOutlet->thermo()->setState_TPX(300, PRESSURE, "O2:1 CH4:0.5 N2:3.76");
+        mixOutlet->thermo()->equilibrate("HP");
+
+        double mdot;
+        double volume;
+        std::cout << "Enter mdot: ";
+        std::cin >> mdot;
+        std::cout << "Enter volume: ";
+        std::cin >> volume;
+
+        PSR reactor(mixInlet, mixOutlet, mdot, volume);
+        reactor.solve();
+
+        std::cout << mixOutlet->thermo()->report() << "\n";
+
+        return 0;
+    }
+    catch (Cantera::CanteraError &err)
+    {
+        std::cerr << err.what() << std::endl;
+        return -1;
+    }
+}

--- a/samples/cxx/psr/PSRv2.cpp
+++ b/samples/cxx/psr/PSRv2.cpp
@@ -1,0 +1,186 @@
+/// @file PSRv2.cpp
+/// Perfectly Stirred Reactor Solver (v0.2)
+
+#include "BoundaryValueProblem.h" // PSR uses the simplified BoundaryValueProblem interface to Cantera's solver (for now)
+
+const char *MECHANISM = "gri30.yaml";
+const double PRESSURE = Cantera::OneAtm;
+
+class PSR : public BVP::BoundaryValueProblem
+{
+public:
+    // constructor
+    PSR(std::shared_ptr<Cantera::Solution> inletSol, std::shared_ptr<Cantera::Solution> reactorSol, double mdot, double volume, bool doEnergy = false, double fixedTemp = 0)
+    // ------------------------ INITIALIZE GLOBAL VARS ------------------------
+    : BVP::BoundaryValueProblem(inletSol->thermo()->nSpecies() + doEnergy, 1, 0.0, 1), // initialize BVP interface. 1st arg is number of solution components, 2nd arg is number of grid points (1 point for 0D...), 3rd and 4th are arbitrary (not used in this problem)
+      inletThermo(inletSol->thermo()),
+      reactorThermo(reactorSol->thermo()),
+      reactorKinetics(reactorSol->kinetics()),
+      nSpecies(inletSol->thermo()->nSpecies()),
+      index_T(inletSol->thermo()->nSpecies()),                 // location of the "Temperature" component in the solution vector
+      Y_in(inletSol->thermo()->massFractions()),               // mass fractions at the inlet
+      molecularWeight(inletSol->thermo()->molecularWeights()), // molecular weight of each species (these never change)
+      volume(volume),
+      mdot(mdot),
+      fixedTemp(fixedTemp * !doEnergy), // bool: true if fixed reactor temperature provided, *always* false if doEnergy = true
+      doEnergy(doEnergy)
+
+    {
+        // ------------------ INITIALIZE SOLUTION COMPONENTS ------------------
+        // solution vector contains nSpecies reactor mass fractions, ordered by species index.
+        // if energy is enabled, reactor temp is added as the final solution component.
+        // i.e.:
+        //     sol = | Y_0 | Y_1 | Y_2 | ... | Y_(nSpecies-1) | Temp |
+        BVP::Component initializer;
+        initializer.lower = -1.0e-3;
+        initializer.upper = 1.01;
+        initializer.rtol = 1.0e-4;
+        initializer.atol = 1.0e-9;
+        initializer.refine = false;
+
+        for (int k = 0; k < nSpecies; k++)
+        {
+            initializer.name = inletThermo->speciesName(k);
+            setComponent(k, initializer);
+        }
+
+        if (doEnergy)
+        {
+            initializer.lower = 200;
+            initializer.upper = 6000;
+            initializer.rtol = 1;
+            initializer.atol = 1;
+            initializer.name = "Temperature";
+            setComponent(index_T, initializer);
+        }
+    }
+
+    // destructor
+    virtual ~PSR() {}
+
+    // Specify guesses for the initial values.
+    virtual doublereal initialValue(size_t i, size_t j)
+    {
+        if (i < nSpecies)
+            return reactorThermo->massFraction(i);
+        return reactorThermo->temperature();
+    }
+
+    // Specify the residual function. The solver will attempt to find a solution
+    // sol so that rsd is zero.
+    void eval(size_t jg, double *sol, double *rsd, int *diag, double rdt)
+    {
+        size_t j = 0; // current grid point (only one point in a 0D problem...)
+
+        // ----------------------- UPDATE REACTOR STATE -----------------------
+        reactorThermo->setMassFractions_NoNorm(sol);
+        // reactorThermo->setMassFractions(sol); -> alternative method, will compare performance between the two
+
+        if (doEnergy)
+            reactorThermo->setState_TP(sol[index_T], PRESSURE); // use the reactor temperature based on the energy equation
+        else if (fixedTemp)
+            reactorThermo->setState_TP(fixedTemp, PRESSURE); // use a fixed reactor temperature (if provided)
+        else
+            reactorThermo->setState_HP(inletThermo->enthalpy_mass(), PRESSURE); // keep total enthalpy constant, allow Cantera to control reactor temperature
+
+        // ----------------------- GET REQ'D PROPERTIES -----------------------
+        double reactorDensity = reactorThermo->density();
+        double resTime = volume * reactorDensity / mdot;
+
+        doublereal wdot[nSpecies];
+        reactorKinetics->getNetProductionRates(wdot);
+
+        // ----------------------- SPECIES CONSERVATION -----------------------
+        for (int k = 0; k < nSpecies; k++)
+        {
+            //rsd[index(i, j)] = wdot[k] * molecularWeight[k] * volume + mdot * (Y_in[k] - sol[k])
+            rsd[k] = wdot[k] * (molecularWeight[k] / reactorDensity) - (sol[k] - Y_in[k]) / resTime;
+
+            // -------------------- TIME INTEGRATION --------------------------
+            if (rdt != 0) // rdt is the reciprocal of the time step "dt".
+            {
+                rsd[k] -= rdt * (sol[k] - prevSoln(k, j)); // backward euler method (will be extracted from the residual)
+                diag[k] = 1;                               // enable time stepping for this solution component (automatically resets each iteration)
+            }
+        }
+
+        // -------------------------- ENERGY EQUATION -------------------------
+        if (doEnergy)
+        {
+            // ------------------ GET REQ'D PROPERTIES ------------------------
+            doublereal reactorCp = reactorThermo->cp_mass();
+
+            // calculate the specific enthalpy of each species:
+            doublereal h_in[nSpecies]; // inlet specific enthalpies
+            inletThermo->getEnthalpy_RT(h_in);
+            doublereal h[nSpecies]; // reactor specific enthalpies
+            reactorThermo->getEnthalpy_RT(h);
+            for (int k = 0; k < nSpecies; k++)
+            {
+                h_in[k] *= inletThermo->RT() * inletThermo->moleFraction(k) / inletThermo->meanMolecularWeight();
+                h[k] *= reactorThermo->RT() * reactorThermo->moleFraction(k) / reactorThermo->meanMolecularWeight();
+            }
+
+            // ----------------------- EVAL ENERGY ----------------------------
+            double sum1 = 0;
+            double sum2 = 0;
+            for (int k = 0; k < nSpecies; k++)
+            {
+                sum1 += Y_in[k] * (h_in[k] - h[k]);
+                sum2 += h[k] * molecularWeight[k] * wdot[k];
+            }
+            rsd[index_T] = sum1 / (reactorCp * resTime) - sum2 / (reactorDensity * reactorCp);
+
+            // -------------------- TIME INTEGRATION --------------------------
+            if (rdt != 0)
+            {
+                rsd[index_T] -= rdt * (sol[index_T] - prevSoln(index_T, j));
+                diag[index_T] = 1;
+            }
+        }
+    }
+
+private:
+    std::shared_ptr<Cantera::ThermoPhase> inletThermo;
+    std::shared_ptr<Cantera::ThermoPhase> reactorThermo;
+    std::shared_ptr<Cantera::Kinetics> reactorKinetics;
+    const int nSpecies;
+    const int index_T;
+    const double *Y_in;
+    Cantera::vector_fp molecularWeight;
+    bool doEnergy;
+    double fixedTemp;
+    double volume;
+    double mdot;
+};
+
+int main()
+{
+    try
+    {
+        std::shared_ptr<Cantera::Solution> mixInlet(Cantera::newSolution(MECHANISM));
+        std::shared_ptr<Cantera::Solution> mixOutlet(Cantera::newSolution(MECHANISM));
+        mixInlet->thermo()->setState_TPX(300, PRESSURE, "O2:1 CH4:0.5 N2:3.76");
+        mixOutlet->thermo()->setState_TPX(300, PRESSURE, "O2:1 CH4:0.5 N2:3.76");
+        mixOutlet->thermo()->equilibrate("HP");
+
+        double mdot;
+        double volume;
+        std::cout << "Enter mdot: ";
+        std::cin >> mdot;
+        std::cout << "Enter volume: ";
+        std::cin >> volume;
+
+        PSR reactor(mixInlet, mixOutlet, mdot, volume);
+        reactor.solve();
+
+        std::cout << mixOutlet->thermo()->report() << "\n";
+
+        return 0;
+    }
+    catch (Cantera::CanteraError &err)
+    {
+        std::cerr << err.what() << std::endl;
+        return -1;
+    }
+}

--- a/samples/cxx/psr/psr.cpp
+++ b/samples/cxx/psr/psr.cpp
@@ -1,0 +1,106 @@
+/// @file psr.cpp
+/// Perfectly Stirred Reactor (v0.1)
+
+#include "BoundaryValueProblem.h"
+
+const char *MECHANISM = "gri30.yaml";
+const double PRESSURE = Cantera::OneAtm;
+
+class PSR : public BVP::BoundaryValueProblem
+{
+public:
+    std::shared_ptr<Cantera::ThermoPhase> inletThermo;
+    std::shared_ptr<Cantera::ThermoPhase> reactorThermo;
+    std::shared_ptr<Cantera::Kinetics> reactorKinetics;
+
+    const double *initialVector;
+    double mdot;
+    double volume;
+
+    // constructor
+    PSR(std::shared_ptr<Cantera::Solution> inletSol, std::shared_ptr<Cantera::Solution> reactorSol, double mdot_input, double volume_input)
+        : BVP::BoundaryValueProblem(inletSol->thermo()->nSpecies(), 1, 0.0, 1)
+    {
+        inletThermo = inletSol->thermo();
+        reactorThermo = reactorSol->thermo();
+        reactorKinetics = reactorSol->kinetics();
+        initialVector = reactorSol->thermo()->massFractions();
+        mdot = mdot_input;
+        volume = volume_input;
+
+        BVP::Component initializer;
+        initializer.lower = 0;
+        initializer.upper = 1;
+        initializer.rtol = 1.0e-12;
+        initializer.atol = 1.0e-15;
+
+        for (int i = 0; i < inletThermo->nSpecies(); i++)
+        {
+            initializer.name = inletThermo->speciesName(i);
+            setComponent(i, initializer);
+        }
+    }
+
+    // destructor
+    virtual ~PSR() {}
+
+    // specify guesses for the initial values. These can be anything
+    // that leads to a converged solution.
+    virtual doublereal initialValue(size_t n, size_t j)
+    {
+        return initialVector[n];
+    }
+
+    // Specify the residual function. This is where the ODE system and boundary
+    // conditions are specified. The solver will attempt to find a solution
+    // x so that rsd is zero.
+    void eval(size_t jg, double *x, double *rsd, int *diag, double rdt)
+    {
+        size_t j = 0;
+
+        reactorThermo->setMassFractions_NoNorm(x);
+        reactorThermo->setState_HP(inletThermo->enthalpy_mass(), PRESSURE);
+
+        Cantera::vector_fp wdot(inletThermo->nSpecies());
+        reactorKinetics->getNetProductionRates(wdot.data());
+
+        for (int i = 0; i < inletThermo->nSpecies(); i++)
+        {
+            rsd[index(i, j)] = wdot.at(i) * inletThermo->molecularWeight(i) * volume + mdot * (inletThermo->massFraction(i) - value(x, i, j));
+        }
+    }
+};
+
+int main()
+{
+    try
+    {
+        double mdot;
+        double volume;
+
+        std::cout << "Enter mdot: ";
+        std::cin >> mdot;
+        std::cout << "\nEnter volume: ";
+        std::cin >> volume;
+
+        std::shared_ptr<Cantera::Solution> mixInlet(Cantera::newSolution(MECHANISM));
+        std::shared_ptr<Cantera::Solution> mixOutlet(Cantera::newSolution(MECHANISM));
+
+        mixInlet->thermo()->setState_TPX(298, PRESSURE, "H2:2 O2:1");
+        mixOutlet->thermo()->setState_TPX(298, PRESSURE, "H2:2 O2:1");
+        mixOutlet->thermo()->equilibrate("HP");
+
+        PSR reactor(mixInlet, mixOutlet, mdot, volume);
+
+        reactor.solve();
+
+        std::cout << mixOutlet->thermo()->report() << "\n";
+
+        return 0;
+    }
+    catch (Cantera::CanteraError &err)
+    {
+        std::cerr << err.what() << std::endl;
+        return -1;
+    }
+}

--- a/src/oneD/MultiJac.cpp
+++ b/src/oneD/MultiJac.cpp
@@ -30,7 +30,8 @@ MultiJac::MultiJac(OneDim& r)
 void MultiJac::updateTransient(doublereal rdt, integer* mask)
 {
     for (size_t n = 0; n < m_size; n++) {
-        value(n,n) = m_ssdiag[n] - mask[n]*rdt;
+        value(n,n) = m_ssdiag[n] - mask[n]*rdt; // transient jacobian-- extract steady state
+        //std::cout << "\n TRANSJAC VALUE..." << value(n,n);
     }
 }
 

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -31,7 +31,7 @@ Sim1D::Sim1D(vector<Domain1D*>& domains) :
     }
 
     // set some defaults
-    m_tstep = 1.0e-5;
+    m_tstep = 1.0e-3;
     m_steps = { 10 };
 }
 
@@ -287,8 +287,9 @@ void Sim1D::solve(int loglevel, bool refine_grid)
                 if (loglevel > 0) {
                     writelog("Take {} timesteps   ", nsteps);
                 }
-                dt = timeStep(nsteps, dt, m_x.data(), m_xnew.data(),
+                dt = timeStep(nsteps, dt, m_x.data(), m_xnew.data(), //TIMESTEP
                               loglevel-1);
+                writelog("\n\n\n -------------------------------------MADE IT OUT OF TIMESTEP \n\n\n");
                 m_xlast_ts = m_x;
                 if (loglevel > 6) {
                     save("debug_sim1d.xml", "debug", "After timestepping");

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -500,11 +500,19 @@ void Reactor::setAdvanceLimit(const string& nm, const double limit)
 void Reactor::residFunction(double *sol, double *rsd)
 {
     // ----------------------- UPDATE REACTOR STATE -----------------------
+    doublereal Hdot = 0;
+    doublereal mdot = 0;
+    evalFlowDevices(0);
+    for (size_t i = 0; i < m_inlet.size(); i++) {
+        Hdot += m_mdot_in[i] * m_inlet[i]->enthalpy_mass();
+        mdot += m_mdot_in[i];
+    }
+    doublereal h = Hdot/mdot;
     m_thermo->restoreState(m_state);
-    doublereal h = m_thermo->enthalpy_mass();
     doublereal p = m_thermo->pressure();
     m_thermo->setMassFractions_NoNorm(sol);
     m_thermo->setState_HP(h,p); // keep total enthalpy constant, allow Cantera to control reactor temperature
+    m_thermo->saveState(m_state);
 
     // ----------------------- GET REQ'D PROPERTIES -----------------------
     const vector_fp& mw = m_thermo->molecularWeights();

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -376,7 +376,7 @@ double ReactorNet::solveSteady()
         m_start.push_back(m_nv);
     }
     //solve
-    Cantera_NonLinSol::solve();
+    Cantera_NonLinSol::solve(8);
 }
 
 doublereal ReactorNet::ctNLS_initialValue(size_t i)

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -368,12 +368,12 @@ size_t ReactorNet::registerSensitivityParameter(
 double ReactorNet::solveSteady()
 {
     //initialize
-    m_SSneq = 0;
-    m_SSstart.assign(1, 0);
+    m_nv = 0;
+    m_start.assign(1, 0);
     for (size_t n = 0; n < m_reactors.size(); n++) {
         Reactor& r = *m_reactors[n];
-        m_SSneq += r.contents().nSpecies();
-        m_SSstart.push_back(m_SSneq);
+        m_nv += r.neq();
+        m_start.push_back(m_nv);
     }
     //solve
     Cantera_NonLinSol::solve();
@@ -382,20 +382,21 @@ double ReactorNet::solveSteady()
 doublereal ReactorNet::ctNLS_initialValue(size_t i)
 {
     for (size_t n = m_reactors.size() - 1; n >= 0; n--)
-        if (i >= m_SSstart[n])
-            return m_reactors[n]->initialValue(i - m_SSstart[n]);
+        if (i >= m_start[n])
+            return m_reactors[n]->initialValue(i - m_start[n]);
     return -1;
 }
 
 void ReactorNet::ctNLS_residFunction(double *sol, double *rsd)
 {
+    //updateState(sol);
     for (size_t n = 0; n < m_reactors.size(); n++)
-        m_reactors[n]->residFunction(sol + m_SSstart[n], rsd + m_SSstart[n]);
+        m_reactors[n]->residFunction(sol + m_start[n], rsd + m_start[n]);
 }
 
 size_t ReactorNet::ctNLS_nEqs()
 {
-    return m_SSneq;
+    return m_nv;
 }
 
 }

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -390,7 +390,7 @@ doublereal ReactorNet::ctNLS_initialValue(size_t i)
 void ReactorNet::ctNLS_residFunction(double *sol, double *rsd)
 {
     for (size_t n = 0; n < m_reactors.size(); n++)
-        m_reactors[n]->residFunction(sol + m_start[n], rsd + m_start[n]);
+        m_reactors[n]->residFunction(sol + m_SSstart[n], rsd + m_SSstart[n]);
 }
 
 size_t ReactorNet::ctNLS_nEqs()

--- a/src/zeroD/flowControllers.cpp
+++ b/src/zeroD/flowControllers.cpp
@@ -33,6 +33,7 @@ void MassFlowController::updateMassFlowRate(double time)
         mdot *= m_tfunc->eval(time);
     }
     m_mdot = std::max(mdot, 0.0);
+    // std::cout << "\n -ACTUAL mdot: " << m_mdot;
 }
 
 PressureController::PressureController() : FlowDevice(), m_master(0) {


### PR DESCRIPTION
Cantera can solve systems of equations representing physically zero-dimensional (i.e., time dependent-only) or one-dimensional (i.e., time + space) systems. The solution of the 1-D problems is done under the assumption of steady state, resulting in a differential-algebraic system of equations to solve. There is a solver implemented in Cantera as part of the 1-D code that solves these problems. 0-D systems can either be transient or steady state, represented by an ODE or algebraic equation respectively; at the moment, the only way to achieve solutions of the steady state problem is to integrate the transient problem until properties stop changing. We would like to modify or implement the existing steady-state 1-D solver for 0-D systems.